### PR TITLE
Added song metadata to 'Now Playing' message

### DIFF
--- a/src/messagehandler.js
+++ b/src/messagehandler.js
@@ -131,14 +131,6 @@ async function playThis (message) {
 			playbackmanager.stop(isSummendByPlay ? discordClient.user.client.voice.connections.first() : undefined);
 			return;
 		}
-		try {
-
-		} catch (e) {
-			const noSong = getDiscordEmbedError(e);
-			message.channel.send(noSong);
-			playbackmanager.stop(isSummendByPlay ? discordClient.user.client.voice.connections.first() : undefined);
-			return;
-		}
 	}
 
 	discordClient.user.client.voice.connections.forEach((element) => {


### PR DESCRIPTION
The 'Now Playing' message now has the song's name and artist.
![image](https://user-images.githubusercontent.com/44522755/94155466-a32e9300-fe87-11ea-87a6-15c201c4f653.png)

`npm run lint` comes out clean.